### PR TITLE
use standard analog sticks with absolute look angle

### DIFF
--- a/Application/src/main/java/com/pepedyne/pepe/controller/JoyConStickHandler.java
+++ b/Application/src/main/java/com/pepedyne/pepe/controller/JoyConStickHandler.java
@@ -21,193 +21,30 @@ public class JoyConStickHandler {
          for (int i = 0; i < historySize; i++)
          {
             // Process the event at historical position i
-            JoyConStickHandler.determineJoyconAndProcessJoystickInput(event, i, dispatcher);
-            for (int j = 0; j < event.getPointerCount(); j++)
-            {
-               // There are never historical events
-               System.out.println("****** Processing Historical Event");
-            }
+            JoyConStickHandler.processJoystickInput(event, i, dispatcher);
          }
 
-         float deltaX = event.getAxisValue(MotionEvent.AXIS_X);
-         float deltaY = event.getAxisValue(MotionEvent.AXIS_Y);
-         System.out.println("(x,y): " + deltaX + ", " + deltaY);
          // Process the current movement sample in the batch (position -1)
-         JoyConStickHandler.determineJoyconAndProcessJoystickInput(event, -1, dispatcher);
+         JoyConStickHandler.processJoystickInput(event, -1, dispatcher);
       }
       return true;
    }
 
-   private static void determineJoyconAndProcessJoystickInput(MotionEvent event, int i, PepeDispatcher dispatcher) {
-      final int joyconUsed = event.getDevice().getProductId();
-      // Determine which JoyCon was the source of the event
-      if (joyconUsed == 8198) // Left JoyCon event
-      {
-         JoyConStickHandler.processLeftJoystickInput(event, i, dispatcher);
-      }
-      else if (joyconUsed == 8199) // Right JoyCon event
-      {
-         JoyConStickHandler.processRightJoystickInput(event, i, dispatcher);
-      }
-   }
-
-   private static void processLeftJoystickInput(MotionEvent event, int historyPos, PepeDispatcher dispatcher) {
-      Log.i("\tPEPE DEBUG", "JoyCon: LEFT");
-// NOTE: This is wrong...straight from Google...This is the vertical motion for JoyCon
+   private static void processJoystickInput(MotionEvent event, int historyPos, PepeDispatcher dispatcher) {
+      Log.i("\tPEPE DEBUG", "JoyCon");
       // Calculate the horizontal distance to move by
       // using the input value from one of these physical controls:
       // the left control stick, hat axis, or the right control stick.
-      float x = getCenteredAxis(event, event.getDevice(), MotionEvent.AXIS_HAT_X, historyPos);
-      if(x == -1){
-         // Up
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Vertical): up");
-         // Do Nothing??
-      }else if(x == 0){
-         // Center
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Vertical): center");
-         // Do Nothing??
-      }else if(x == 1) {
-         // Down
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Vertical): down");
-         // Do Nothing??
-      }
-// NOTE: This is wrong...straight from Google...This is the Horizontal motion for JoyCon
-      // Calculate the vertical distance to move by
-      // using the input value from one of these physical controls:
-      // the left control stick, hat switch, or the right control stick.
-      float y = getCenteredAxis(event, event.getDevice(), MotionEvent.AXIS_HAT_Y, historyPos);
-      if(y == -1){
-         // Right
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Horizontal): right");
-         dispatcher.turnRight();
-         dispatcher.sendIt();
-      }else if(y == 0){
-         // Center
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Horizontal): center");
-         dispatcher.resetTurn();
-         dispatcher.sendIt();
-      }else if(y == 1) {
-         // Left
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Horizontal): left");
-         dispatcher.turnLeft();
-         dispatcher.sendIt();
-      }
-//      InputDevice mInputDevice = event.getDevice();
-//
-//      // Calculate the horizontal distance to move by
-//      // using the input value from one of these physical controls:
-//      // the left control stick, hat axis, or the right control stick.
-//      float x = getCenteredAxis(event, mInputDevice,
-//              MotionEvent.AXIS_X, historyPos);
-//      if (x == 0)
-//      {
-//         x = getCenteredAxis(event, mInputDevice,
-//                 MotionEvent.AXIS_HAT_X, historyPos);
-//      }
-//      if (x == 0)
-//      {
-//         x = getCenteredAxis(event, mInputDevice,
-//                 MotionEvent.AXIS_Z, historyPos);
-//      }
-//
-//      // Calculate the vertical distance to move by
-//      // using the input value from one of these physical controls:
-//      // the left control stick, hat switch, or the right control stick.
-//      float y = getCenteredAxis(event, mInputDevice,
-//              MotionEvent.AXIS_Y, historyPos);
-//      if (y == 0)
-//      {
-//         y = getCenteredAxis(event, mInputDevice,
-//                 MotionEvent.AXIS_HAT_Y, historyPos);
-//      }
-//      if (y == 0)
-//      {
-//         y = getCenteredAxis(event, mInputDevice,
-//                 MotionEvent.AXIS_RZ, historyPos);
-//      }
-//
-//      // Update the ship object based on the new x and y values
-//      Log.i("PEPE_DEBUG", "************************ (x,y): " + x + ", " + y);
-   }
+      float leftX = getCenteredAxis(event, event.getDevice(), MotionEvent.AXIS_X, historyPos);
+      float leftY = getCenteredAxis(event, event.getDevice(), MotionEvent.AXIS_Y, historyPos);
+      float rightX = getCenteredAxis(event, event.getDevice(), MotionEvent.AXIS_Z, historyPos);
+      float rightY = getCenteredAxis(event, event.getDevice(), MotionEvent.AXIS_RZ, historyPos);
+      // Update the ship object based on the new x and y values
+      Log.i("PEPE_DEBUG", "************************ (x,y): " + leftX + ", " + leftY +
+              ", " + rightX + ", " + rightY);
 
-   private static void processRightJoystickInput(MotionEvent event,
-                                                 int historyPos, PepeDispatcher dispatcher) {
-      Log.i("\tPEPE DEBUG", "JoyCon: RIGHT");
-// NOTE: This is wrong...straight from Google...This is the vertical motion for JoyCon
-      // Calculate the horizontal distance to move by
-      // using the input value from one of these physical controls:
-      // the left control stick, hat axis, or the right control stick.
-      float x = getCenteredAxis(event, event.getDevice(), MotionEvent.AXIS_HAT_X, historyPos);
-      if(x == -1){
-         // Down
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Vertical): down");
-         // Do Nothing??
-      }else if(x == 0){
-         // Center
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Vertical): center");
-         // Do Nothing??
-      }else if(x == 1) {
-         // Up
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Vertical): up");
-         // Do Nothing??
-      }
-// NOTE: This is wrong...straight from Google...This is the Horizontal motion for JoyCon
-      // Calculate the vertical distance to move by
-      // using the input value from one of these physical controls:
-      // the left control stick, hat switch, or the right control stick.
-      float y = getCenteredAxis(event, event.getDevice(), MotionEvent.AXIS_HAT_Y, historyPos);
-      if(y == -1){
-         // left
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Horizontal): left");
-         dispatcher.lookLeft();
-         dispatcher.sendIt();
-      }else if(y == 0){
-         // Center
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Horizontal): center");
-         dispatcher.resetLook();
-         dispatcher.sendIt();
-      }else if(y == 1) {
-         // Right
-         Log.i("\tPEPE DEBUG", "JoyCon: joystick(Horizontal): right");
-         dispatcher.lookRight();
-         dispatcher.sendIt();
-      }
-//      InputDevice mInputDevice = event.getDevice();
-//
-//      // Calculate the horizontal distance to move by
-//      // using the input value from one of these physical controls:
-//      // the left control stick, hat axis, or the right control stick.
-//      float x = getCenteredAxis(event, mInputDevice,
-//              MotionEvent.AXIS_X, historyPos);
-//      if (x == 0)
-//      {
-//         x = getCenteredAxis(event, mInputDevice,
-//                 MotionEvent.AXIS_HAT_X, historyPos);
-//      }
-//      if (x == 0)
-//      {
-//         x = getCenteredAxis(event, mInputDevice,
-//                 MotionEvent.AXIS_Z, historyPos);
-//      }
-//
-//      // Calculate the vertical distance to move by
-//      // using the input value from one of these physical controls:
-//      // the left control stick, hat switch, or the right control stick.
-//      float y = getCenteredAxis(event, mInputDevice,
-//              MotionEvent.AXIS_Y, historyPos);
-//      if (y == 0)
-//      {
-//         y = getCenteredAxis(event, mInputDevice,
-//                 MotionEvent.AXIS_HAT_Y, historyPos);
-//      }
-//      if (y == 0)
-//      {
-//         y = getCenteredAxis(event, mInputDevice,
-//                 MotionEvent.AXIS_RZ, historyPos);
-//      }
-//
-//      // Update the ship object based on the new x and y values
-//      Log.i("PEPE_DEBUG", "************************ (x,y): " + x + ", " + y);
+      dispatcher.turnTo(leftY);
+      dispatcher.sendIt();
    }
 
    private static float getCenteredAxis(MotionEvent event,
@@ -233,19 +70,5 @@ public class JoyConStickHandler {
          }
       }
       return 0;
-   }
-
-   private static void debugMotionEvent(MotionEvent event) {
-      Log.d("\tPEPE_DEBUG", "--------------------------");
-      Log.d("\tPEPE_DEBUG", " MotionEvent Device: " + event.getDevice());
-      Log.d("\tPEPE_DEBUG", " MotionEvent DeviceId: " + event.getDeviceId());
-      Log.d("\tPEPE_DEBUG", " MotionEvent Id: " + event.getDevice().getId());
-      Log.d("\tPEPE_DEBUG", " MotionEvent getFlags: " + event.getFlags());
-      Log.d("\tPEPE_DEBUG", " MotionEvent getDownTime: " + event.getDownTime());
-      Log.d("\tPEPE_DEBUG", " MotionEvent getHistorySize: " + event.getHistorySize());
-      Log.d("\tPEPE_DEBUG", " MotionEvent getPointerCount: " + event.getPointerCount());
-//      Log.d ("\tPEPE DEBUG MotionEvent getPointerCount: " + event.getAxisValue(MotionEvent.AXIS_X, Motion));
-      Log.d("\tPEPE_DEBUG", " MotionEvent MetaState: " + event.getMetaState());
-//      Log.d ("\tPEPE DEBUG KeyEvent getAction: " + event.getAction());
    }
 }

--- a/Application/src/main/java/com/pepedyne/pepe/controller/PepeBluetoothConnectionManager.java
+++ b/Application/src/main/java/com/pepedyne/pepe/controller/PepeBluetoothConnectionManager.java
@@ -335,6 +335,12 @@ public class PepeBluetoothConnectionManager {
       ((StandardServo) this.turn).setCurrent(this.turn.getLimit().getMean());
    }
 
+   public void turnTo(float angle) {
+      angle = Math.max(-1.0f, Math.min(angle, 1.0f));
+      float value = 0.5f * angle * this.turn.getLimit().getRange() + this.turn.getLimit().getMean();
+      this.turn.setCurrent((int)value);
+   }
+
    public void lookLeft() {
       ((StandardServo) this.look).setMin();
    }

--- a/Application/src/main/java/com/pepedyne/pepe/dispatch/PepeDispatcher.java
+++ b/Application/src/main/java/com/pepedyne/pepe/dispatch/PepeDispatcher.java
@@ -111,6 +111,12 @@ public class PepeDispatcher {
       handler.sendData();
    }
 
+   public void turnTo(float angle) {
+      Log.d("PEPE DEBUG", "turn to " + angle);
+      pepeManager.turnTo(angle);
+      handler.sendData();
+   }
+
    public void lookLeft() {
        Log.d("PEPE DEBUG", "look left");
       pepeManager.lookLeft();


### PR DESCRIPTION
This seems to mostly work on my phone. I don't have JoyCons so I used an old XBox 360 controller and I don't have Pepe so I used my Vive basestations (luckily the app doesn't care if the connection fails). According the Android documentation, the right stick should be Z+RZ, but on my controller those axis actually correspond to the triggers.

This probably doesn't work exactly the same for JoyCons because it looks like your JoyCons were coming up as two different controllers before. You can probably apply similar logic to get the JoyCon analog sticks to come up, but for now only the left stick does anything so only one JoyCon is required to have enough inputs anyway.

I changed the code for turning to be analog values mapped directly to the left stick Y axis. This means theoretically Pepe will turn in the desired direction and then turn back to approximately straight when the stick is released. If you want him to stay looking the same direction after releasing the stick you'll need something with velocity instead, but that will take more complicated logic to keep recalculating the next servo position to send. You might want some of that logic anyway to smooth out the motion depending on how this looks.